### PR TITLE
Avoid ctypes using pyroot native behaviour

### DIFF
--- a/nittygriddy/merge.py
+++ b/nittygriddy/merge.py
@@ -1,6 +1,5 @@
 import os
 from pprint import pprint
-import ctypes
 
 import subprocess
 
@@ -22,7 +21,7 @@ def merge(args):
         quit()
 
     ROOT.gROOT.LoadMacro(r'GetSetting.C')
-    if ctypes.c_char_p(ROOT.gROOT.ProcessLine(r'GetSetting("runmode").c_str()')).value != "grid":
+    if ROOT.GetSetting("runmode") != "grid":
         raise ValueError("The data in this folder was not run on the grid!")
 
     # root does not like it if the stdout is piped and it uses some shell functionality


### PR DESCRIPTION
Hi Christian,
this is a minor change. I changed those lines as I came across this error:

```
Starting ROOT version 5.34/30.
(const char* 0x7feca30dda11)"grid"
ValueError: The data in this folder was not run on the grid!
```

I am not sure why it is happening, but with this patch it works.
Cheers,
Max