### PR TITLE
Use MLTrainDefinition.cfg for local analysis

### DIFF
--- a/nittygriddy/GetSetting.C
+++ b/nittygriddy/GetSetting.C
@@ -36,7 +36,7 @@ std::string GetSetting(const std::string settingName) {{
       return "{max_files_subjob}";
     else if (settingName == "use_train_conf")
       return "{use_train_conf}";
-    else if (settingName == "")
+    else
       std::cout << "Invalid setting name: " << settingName << std::endl;
     return "";
   }};

--- a/nittygriddy/utils.py
+++ b/nittygriddy/utils.py
@@ -372,5 +372,36 @@ def prepare_get_setting_c_file(output_dir, args):
                    par_files=args.par_files if args.par_files else "",
                    ttl=args.ttl,
                    max_files_subjob=args.max_files_subjob,
-                   use_train_conf="true" if args.use_train_conf else "false")
+                   use_train_conf="true" if project_uses_train_cfg() else "false")
         get_setting_c.write(as_string)
+
+
+def is_valid_project_dir():
+    """
+    Check if the current directory is a valid "project" directory.
+
+    Raises
+    ------
+    ValueError:
+        If the current directory does not meet the standards
+    """
+    cur_dir = os.path.abspath(os.path.curdir)
+    wagon_conf_file = os.path.isfile(os.path.join(cur_dir, "ConfigureWagon.C"))
+    train_conf = os.path.isfile(os.path.join(cur_dir, "MLTrainDefinition.cfg"))
+
+    # Project dir has either an ConfigureWagon.C or a
+    # MLTrainDefinition.cfg file, but not both
+    if not (wagon_conf_file or train_conf) and (wagon_conf_file ^ train_conf):
+        raise ValueError("Can only run from a nittygriddy project folder! "
+                         "A project folder has either an `ConfigureWagon.C` or a "
+                         "`MLTrainDefinition.cfg` file, but not both.")
+
+
+def project_uses_ConfigureWagon():
+    cur_dir = os.path.abspath(os.path.curdir)
+    return os.path.isfile(os.path.join(cur_dir, "ConfigureWagon.C"))
+
+
+def project_uses_train_cfg():
+    cur_dir = os.path.abspath(os.path.curdir)
+    return os.path.isfile(os.path.join(cur_dir, "MLTrainDefinition.cfg"))


### PR DESCRIPTION
This consolidates the usage of `MLTrainDefinition.cfg` with nittygriddy. Namely, it adds tasks in a way which can also be used for `local` and proof `lite` analyses.

This might break some code! See this comment from one of the commits:

setup tasks independent of AnalysisAlien plugin

I think this is the right way to go, but some analysis seem to use dark
magic that breaks the streaming(?) to the grid. Current solution works
with simple tasks, eg:

```
#_______________________________________________________________________________
#Module.Begin        PhysicsSelection
#Module.Libs
#Module.DataTypes    ESD, AOD, MC
#Module.MacroName    $ALICE_PHYSICS/OADB/macros/AddTaskPhysicsSelection.C
#Module.MacroArgs    kFALSE, kTRUE
#Module.Deps
#Module.Owner        cjahnke
#Module.OutputFile   jpsi_Default.root
#Module.StartConfig

#Module.EndConfig
```
This works in proof lite as well as on the grid.

The advantage of loading the task this way is that it is identical for
running locally and on the grid and thus reduces possible errors down
the road
