### PR TITLE
Runs per masterjob

### DIFF
--- a/nittygriddy/GetSetting.C
+++ b/nittygriddy/GetSetting.C
@@ -36,6 +36,8 @@ std::string GetSetting(const std::string settingName) {{
       return "{max_files_subjob}";
     else if (settingName == "use_train_conf")
       return "{use_train_conf}";
+    else if (settingName == "runs_per_master")
+      return "{runs_per_master}";
     else
       std::cout << "Invalid setting name: " << settingName << std::endl;
     return "";

--- a/nittygriddy/run.C
+++ b/nittygriddy/run.C
@@ -117,6 +117,9 @@ AliAnalysisGrid* CreateAlienHandler(const std::string gridMode) {
   plugin->SetSplitMaxInputFileNumber(atoi(GetSetting("max_files_subjob").c_str()));
   plugin->SetMergeExcludes("EventStat_temp.root"
 			   "event_stat.root");
+  int runs_per_master = atoi(GetSetting("runs_per_master").c_str());
+  int n_runs = TString(GetSetting("run_list").c_str()).CountChar(' ') + 1;
+  plugin->SetNrunsPerMaster(runs_per_master > 0 ? runs_per_master : n_runs);
   // Use run number as output folder names
   plugin->SetOutputToRunNo();
   plugin->SetTTL(atoi(GetSetting("ttl").c_str()));

--- a/nittygriddy/run.py
+++ b/nittygriddy/run.py
@@ -114,4 +114,7 @@ def create_subparsers(subparsers):
     parser_run.add_argument('--max_files_subjob', type=str, help="Maximum number of files per subjob", default="50")
     parser_run.add_argument('--wait_for_gdb', action='store_true', default=False,
                             help="Pause the execution to allow for connecting gdb to the process")
+    parser_run.add_argument('--runs_per_master', type=str, default="1",
+                            help="Number of runs to be processed by each master job. Set it to 0 to process\
+                            the entire runlist with one masterjob.")
     parser_run.set_defaults(op=run)

--- a/nittygriddy/utils.py
+++ b/nittygriddy/utils.py
@@ -422,7 +422,8 @@ def prepare_get_setting_c_file(output_dir, args):
                    par_files=args.par_files if args.par_files else "",
                    ttl=args.ttl,
                    max_files_subjob=args.max_files_subjob,
-                   use_train_conf="true" if project_uses_train_cfg() else "false")
+                   use_train_conf="true" if project_uses_train_cfg() else "false",
+                   runs_per_master=args.runs_per_master)
         get_setting_c.write(as_string)
 
 


### PR DESCRIPTION
Hi @cbourjau!

This pr enables the possibility of using a single masterjob for groups of runs, this is especially interesting when analysing sample with a large number of runs (e.g. LHC16k). If the option is set to 0, all the runs are analysed by a single masterjob.
Please check if everything is OK with you!

Cheers,
Max