### PR TITLE
include user_ds in the return of get_datasets

### DIFF
--- a/nittygriddy/utils.py
+++ b/nittygriddy/utils.py
@@ -69,7 +69,9 @@ def get_datasets():
         raise ValueError("The following user datasets are also in the default definitions. "
                          "Please rename your ones in `~/nitty_datasets.yml`:\n {}"
                          .format('/n'.join(intersect)))
-    return default_ds
+    full_ds=dict(default_ds)
+    full_ds.update(user_ds)
+    return full_ds
 
 
 def copy_template_files_to(dest):


### PR DESCRIPTION
issue: get_datasets in utils.py return defaults_ds datasets only.

This PR proposes a method to fix the issue of ignoring  user_ds information in the return of get_datasets.