### PR TITLE
Fix url list in datasets download

### DIFF
--- a/nittygriddy/utils.py
+++ b/nittygriddy/utils.py
@@ -170,7 +170,7 @@ def find_associated_archive_files(datadir, run_number_prefix, runs, data_pattern
             # line, we avoid some of this crap by fishing out the urls
             # manually from the TGridResult...
             gr = finds.GetGridResult()
-            urls = [str(el.GetValue('turl')).replace("alien://", "") for el in gr]
+            urls.extend([str(el.GetValue('turl')).replace("alien://", "") for el in gr])
         # Did we find any files? If not, lets try it with the next archive name
         if len(urls) != 0:
             break


### PR DESCRIPTION
Ciao @cbourjau,
the patch itself is self-expaining: the url list was being replaced for each run, I guess that the intended behaviour was extending it for every run.
See you tomorrow in Frascati,

Max